### PR TITLE
fix: Compact機能の初期化時の不具合を修正

### DIFF
--- a/app/renderer/features/diff/DiffEditor.tsx
+++ b/app/renderer/features/diff/DiffEditor.tsx
@@ -40,6 +40,7 @@ const DiffEditor = forwardRef<DiffEditorRef, DiffEditorProps>(
     const [showComparePanel, setShowComparePanel] = useState(true);
     const [leftContent, setLeftContent] = useState('');
     const [rightContent, setRightContent] = useState('');
+    const [editorMounted, setEditorMounted] = useState(false);
 
     // usePanelResizeフックを使用
     const {
@@ -56,6 +57,7 @@ const DiffEditor = forwardRef<DiffEditorRef, DiffEditorProps>(
     useCompactMode(diffEditorRef, {
       compactMode: activeSession?.options.compactMode ?? false,
       viewMode: activeSession?.options.viewMode ?? 'side-by-side',
+      editorMounted,
     });
 
     // storeから言語を取得
@@ -279,6 +281,7 @@ const DiffEditor = forwardRef<DiffEditorRef, DiffEditorProps>(
     // Diffエディタのマウント処理
     const handleDiffEditorDidMount = (editor: editor.IStandaloneDiffEditor) => {
       diffEditorRef.current = editor;
+      setEditorMounted(true);
     };
 
     // 共通エディタオプション

--- a/app/renderer/features/diff/hooks/useCompactMode.ts
+++ b/app/renderer/features/diff/hooks/useCompactMode.ts
@@ -9,6 +9,8 @@ export interface UseCompactModeOptions {
   compactMode: boolean;
   /** 表示モード（unified/side-by-side） */
   viewMode: 'unified' | 'side-by-side';
+  /** エディターがマウントされたかどうか */
+  editorMounted?: boolean;
 }
 
 /**
@@ -342,6 +344,8 @@ export const useCompactMode = (
     fixUnifiedModeCharHighlights();
   }, [options.compactMode, clearCompactDecorations, fixUnifiedModeCharHighlights, diffEditorRef]);
 
+  // diff更新時と設定変更時に装飾を再適用
+  // biome-ignore lint/correctness/useExhaustiveDependencies: editorMountedはエディターマウント時の再実行トリガーとして必要
   useEffect(() => {
     const diffEditor = diffEditorRef.current;
     if (!diffEditor) return;
@@ -350,11 +354,18 @@ export const useCompactMode = (
       updateCompactDecorations();
     });
 
+    // 初回マウント時とcompactMode変更時に装飾を適用
     updateCompactDecorations();
 
     return () => {
       listener.dispose();
       clearCompactDecorations();
     };
-  }, [updateCompactDecorations, clearCompactDecorations, diffEditorRef]);
+  }, [
+    updateCompactDecorations,
+    clearCompactDecorations,
+    diffEditorRef,
+    options.compactMode,
+    options.editorMounted,
+  ]);
 };

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.2/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.5/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.2/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "zustand": "^5.0.8"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.3.2",
+        "@biomejs/biome": "^2.3.5",
         "@playwright/test": "^1.56.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -430,9 +430,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.4.tgz",
-      "integrity": "sha512-TU08LXjBHdy0mEY9APtEtZdNQQijXUDSXR7IK1i45wgoPD5R0muK7s61QcFir6FpOj/RP1+YkPx5QJlycXUU3w==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.5.tgz",
+      "integrity": "sha512-HvLhNlIlBIbAV77VysRIBEwp55oM/QAjQEin74QQX9Xb259/XP/D5AGGnZMOyF1el4zcvlNYYR3AyTMUV3ILhg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -446,20 +446,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.3.4",
-        "@biomejs/cli-darwin-x64": "2.3.4",
-        "@biomejs/cli-linux-arm64": "2.3.4",
-        "@biomejs/cli-linux-arm64-musl": "2.3.4",
-        "@biomejs/cli-linux-x64": "2.3.4",
-        "@biomejs/cli-linux-x64-musl": "2.3.4",
-        "@biomejs/cli-win32-arm64": "2.3.4",
-        "@biomejs/cli-win32-x64": "2.3.4"
+        "@biomejs/cli-darwin-arm64": "2.3.5",
+        "@biomejs/cli-darwin-x64": "2.3.5",
+        "@biomejs/cli-linux-arm64": "2.3.5",
+        "@biomejs/cli-linux-arm64-musl": "2.3.5",
+        "@biomejs/cli-linux-x64": "2.3.5",
+        "@biomejs/cli-linux-x64-musl": "2.3.5",
+        "@biomejs/cli-win32-arm64": "2.3.5",
+        "@biomejs/cli-win32-x64": "2.3.5"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.4.tgz",
-      "integrity": "sha512-w40GvlNzLaqmuWYiDU6Ys9FNhJiclngKqcGld3iJIiy2bpJ0Q+8n3haiaC81uTPY/NA0d8Q/I3Z9+ajc14102Q==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.5.tgz",
+      "integrity": "sha512-fLdTur8cJU33HxHUUsii3GLx/TR0BsfQx8FkeqIiW33cGMtUD56fAtrh+2Fx1uhiCsVZlFh6iLKUU3pniZREQw==",
       "cpu": [
         "arm64"
       ],
@@ -474,9 +474,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.4.tgz",
-      "integrity": "sha512-3s7TLVtjJ7ni1xADXsS7x7GMUrLBZXg8SemXc3T0XLslzvqKj/dq1xGeBQ+pOWQzng9MaozfacIHdK2UlJ3jGA==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.5.tgz",
+      "integrity": "sha512-qpT8XDqeUlzrOW8zb4k3tjhT7rmvVRumhi2657I2aGcY4B+Ft5fNwDdZGACzn8zj7/K1fdWjgwYE3i2mSZ+vOA==",
       "cpu": [
         "x64"
       ],
@@ -491,9 +491,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.4.tgz",
-      "integrity": "sha512-y7efHyyM2gYmHy/AdWEip+VgTMe9973aP7XYKPzu/j8JxnPHuSUXftzmPhkVw0lfm4ECGbdBdGD6+rLmTgNZaA==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.5.tgz",
+      "integrity": "sha512-u/pybjTBPGBHB66ku4pK1gj+Dxgx7/+Z0jAriZISPX1ocTO8aHh8x8e7Kb1rB4Ms0nA/SzjtNOVJ4exVavQBCw==",
       "cpu": [
         "arm64"
       ],
@@ -508,9 +508,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.4.tgz",
-      "integrity": "sha512-IruVGQRwMURivWazchiq7gKAqZSFs5so6gi0hJyxk7x6HR+iwZbO2IxNOqyLURBvL06qkIHs7Wffl6Bw30vCbQ==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.5.tgz",
+      "integrity": "sha512-eGUG7+hcLgGnMNl1KHVZUYxahYAhC462jF/wQolqu4qso2MSk32Q+QrpN7eN4jAHAg7FUMIo897muIhK4hXhqg==",
       "cpu": [
         "arm64"
       ],
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.4.tgz",
-      "integrity": "sha512-gKfjWR/6/dfIxPJCw8REdEowiXCkIpl9jycpNVHux8aX2yhWPLjydOshkDL6Y/82PcQJHn95VCj7J+BRcE5o1Q==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.5.tgz",
+      "integrity": "sha512-XrIVi9YAW6ye0CGQ+yax0gLfx+BFOtKaNX74n+xHWla6Cl6huUmcKNO7HPx7BiKnJUzrxXY1qYlm7xMvi08X4g==",
       "cpu": [
         "x64"
       ],
@@ -542,9 +542,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.4.tgz",
-      "integrity": "sha512-mzKFFv/w66e4/jCobFmD3kymCqG+FuWE7sVa4Yjqd9v7qt2UhXo67MSZKY9Ih18V2IwPzRKQPCw6KwdZs6AXSA==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.5.tgz",
+      "integrity": "sha512-awVuycTPpVTH/+WDVnEEYSf6nbCBHf/4wB3lquwT7puhNg8R4XvonWNZzUsfHZrCkjkLhFH/vCZK5jHatD9FEg==",
       "cpu": [
         "x64"
       ],
@@ -559,9 +559,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.4.tgz",
-      "integrity": "sha512-5TJ6JfVez+yyupJ/iGUici2wzKf0RrSAxJhghQXtAEsc67OIpdwSKAQboemILrwKfHDi5s6mu7mX+VTCTUydkw==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.5.tgz",
+      "integrity": "sha512-DlBiMlBZZ9eIq4H7RimDSGsYcOtfOIfZOaI5CqsWiSlbTfqbPVfWtCf92wNzx8GNMbu1s7/g3ZZESr6+GwM/SA==",
       "cpu": [
         "arm64"
       ],
@@ -576,9 +576,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.4.tgz",
-      "integrity": "sha512-FGCijXecmC4IedQ0esdYNlMpx0Jxgf4zceCaMu6fkjWyjgn50ZQtMiqZZQ0Q/77yqPxvtkgZAvt5uGw0gAAjig==",
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.5.tgz",
+      "integrity": "sha512-nUmR8gb6yvrKhtRgzwo/gDimPwnO5a4sCydf8ZS2kHIJhEmSmk+STsusr1LHTuM//wXppBawvSQi2xFXJCdgKQ==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.2",
+    "@biomejs/biome": "^2.3.5",
     "@playwright/test": "^1.56.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -23,7 +23,6 @@ export default defineConfig({
       'dist',
       'app/renderer/features/diff/utils/**', // Monaco Editor依存
       'app/renderer/features/diff/themes/**', // Monaco Editor依存
-      'app/renderer/features/diff/hooks/useCompactMode.test.ts', // Monaco Editor依存
     ],
     passWithNoTests: true,
     coverage: {
@@ -41,7 +40,6 @@ export default defineConfig({
         'app/renderer/features/diff/DiffEditor.tsx', // Monaco Editor integration (tested via mocks)
         'app/renderer/features/diff/utils/**', // Monaco Editor依存 (モックの問題でテスト除外)
         'app/renderer/features/diff/themes/**', // Monaco Editor依存
-        'app/renderer/features/diff/hooks/useCompactMode.ts', // Monaco Editor依存
       ],
       thresholds: {
         lines: 0, // Start with no threshold, can be increased later


### PR DESCRIPTION
## 変更内容

- 設定でCompactモードが最初から有効な場合に装飾が適用されない不具合を修正
- エディターのマウント状態を追跡し、マウント完了時に装飾を適用するように変更

## 問題

- 設定でCompactモードが最初から有効な場合、装飾が適用されない
- チェックボックスをオフ・オンすると正常に動作する

## 原因

- `useCompactMode`フックの初回レンダリング時にMonaco Editorがまだマウントされていない
- Reactは`ref.current`の変更を検知しないため、エディターがマウントされても`useEffect`が再実行されない
- テーマ（透明背景）だけが適用され、文字レベルのハイライトが表示されない

## 解決方法

1. `DiffEditor.tsx`に`editorMounted`状態を追加
2. `handleDiffEditorDidMount`内で`setEditorMounted(true)`を呼ぶ
3. `useCompactMode`フックに`editorMounted`プロパティを追加
4. `useEffect`の依存配列に`options.editorMounted`を追加
5. エディターがマウントされた時点で`compactMode`が有効なら装飾を適用

## テスト結果

```bash
npm run test
```

- ✅ 全18ユニットテスト成功（useCompactMode.test.ts）
- ✅ 全445テスト成功
- ✅ 型チェック成功
- ✅ リント成功
- ✅ 手動テストで動作確認済み

## 影響範囲

- `app/renderer/features/diff/DiffEditor.tsx`
- `app/renderer/features/diff/hooks/useCompactMode.ts`
- `app/renderer/features/diff/hooks/useCompactMode.test.ts`
- `vitest.config.mts`（テスト除外設定を削除）
- `biome.json`（スキーマ更新）

## 動作確認

1. 設定でCompactモードを有効にする
2. アプリを再起動
3. 左右のエディターに異なるテキストを貼り付ける
4. **期待する動作**: 即座に文字レベルのハイライト（緑/赤の装飾）が表示される ✅